### PR TITLE
Add conversion rules for bem-depth and no-trailing-zero

### DIFF
--- a/tests/rules.js
+++ b/tests/rules.js
@@ -257,6 +257,30 @@ describe('Rule Conversion', function () {
     );
   });
 
+  it('BemDepth', function () {
+    assert.deepStrictEqual(
+      scss2sass.convert({
+        linters: {
+          'BemDepth': { enabled: true }
+        }
+      }).rules,
+      {
+        'bem-depth': 1
+      }
+    );
+
+    assert.deepStrictEqual(
+      scss2sass.convert({
+        linters: {
+          'BemDepth': { enabled: true, max_elements: 3 }
+        }
+      }).rules,
+      {
+        'bem-depth': [1, { 'max-depth': 3 }]
+      }
+    );
+  });
+
   it('BorderZero', function () {
     assert.deepStrictEqual(
       scss2sass.convert({
@@ -1150,6 +1174,17 @@ describe('Rule Conversion', function () {
         }
       }).rules,
       { 'no-transition-all': 1 }
+    );
+  });
+
+  it('UnnecessaryMantissa', function () {
+    assert.deepStrictEqual(
+      scss2sass.convert({
+        linters: {
+          'UnnecessaryMantissa': { enabled: true }
+        }
+      }).rules,
+      { 'no-trailing-zero': 1 }
     );
   });
 

--- a/translations.js
+++ b/translations.js
@@ -22,6 +22,16 @@ module.exports.BangFormat = {
   }
 };
 
+module.exports.BemDepth = {
+  name: 'bem-depth',
+  defaultDisabled: true,
+  options: {
+    max_elements: {
+      name: 'max-depth'
+    }
+  }
+};
+
 module.exports.BorderZero = {
   name: 'border-zero',
   options: {
@@ -335,6 +345,7 @@ module.exports.StringQuotes = {
 module.exports.TrailingSemicolon = { name: 'trailing-semicolon' };
 module.exports.TrailingZero = { name: 'no-trailing-zero', defaultDisabled: true };
 module.exports.TransitionAll = { name: 'no-transition-all', defaultDisabled: true };
+module.exports.UnnecessaryMantissa = { name: 'no-trailing-zero' };
 module.exports.UrlFormat = { name: 'no-url-protocols' };
 module.exports.UrlQuotes = { name: 'url-quotes' };
 


### PR DESCRIPTION
I hope it's not too forward to add these two rules to `make-sass-lint-config`.  I noticed that you were the only committer after I had added the rule for `no-trailing-zero` to replace `unnecessary-mantissa`.

Given that I updated `no-trailing-zero` (and it was this library that led me to find it was unimplemented in the first place), I thought I would add an update here for this.  While I was at it, I noticed you merged the pull request for `bem-depth`, so I added that as well.

Again, sorry if you aren't accepting pull requests for this project.  Just thought I would try to help. :smiley: 

Conversions:
- `UnnecessaryMantissa` became `no-trailing-zero`
- `BemDepth` became `bem-depth` (with option `max_elements` becoming `max-depth`)
