### PR TITLE
Update ColorKeyword rule key

### DIFF
--- a/tests/rules.js
+++ b/tests/rules.js
@@ -323,7 +323,7 @@ describe('Rule Conversion', function () {
           'ColorKeyword': { enabled: true }
         }
       }).rules,
-      { 'no-color-keyword': 1 }
+      { 'no-color-keywords': 1 }
     );
   });
 

--- a/translations.js
+++ b/translations.js
@@ -41,7 +41,7 @@ module.exports.BorderZero = {
   }
 };
 
-module.exports.ColorKeyword = { name: 'no-color-keyword' };
+module.exports.ColorKeyword = { name: 'no-color-keywords' };
 module.exports.ColorVariable = { name: 'no-color-literals' };
 module.exports.Comment = { name: 'no-css-comments' };
 module.exports.DebugStatement = { name: 'no-debug' };


### PR DESCRIPTION
sass-lint has named this rule 'no-color-keywords' not 'no-color-keyword'
