### PR TITLE
Fix convention on border-zero rule

### DIFF
--- a/tests/rules.js
+++ b/tests/rules.js
@@ -300,7 +300,7 @@ describe('Rule Conversion', function () {
         }
       }).rules,
       {
-        'border-zero': [1, { convention: 'zero' }]
+        'border-zero': [1, { convention: '0' }]
       }
     );
 

--- a/translations.js
+++ b/translations.js
@@ -33,10 +33,18 @@ module.exports.BemDepth = {
 };
 
 module.exports.BorderZero = {
-  name: 'border-zero',
-  options: {
-    convention: {
-      name: 'convention'
+  special_case: function (linterValue, sassSettings, severity) {
+    if (linterValue.hasOwnProperty('convention')) {
+      var convention = linterValue.convention;
+      if (convention === 'zero') {
+        sassSettings.rules['border-zero'] = [severity, { convention: '0' }];
+      }
+      else {
+        sassSettings.rules['border-zero'] = [severity, { convention: convention }];
+      }
+    }
+    else {
+      sassSettings.rules['border-zero'] = severity;
     }
   }
 };


### PR DESCRIPTION
Not `'zero'` but `'0'` is used for `convention` option in `border-zero` rule.

https://github.com/sasstools/sass-lint/blob/develop/docs/rules/border-zero.md
